### PR TITLE
fixed costCombo error

### DIFF
--- a/esstoolkit/catchment_analyser/catchment_analyser_dialog.py
+++ b/esstoolkit/catchment_analyser/catchment_analyser_dialog.py
@@ -146,7 +146,7 @@ class CatchmentAnalyserDialog(QDialog, FORM_CLASS):
             self.costCombo.addItems(['length'] + names)
         else:
             fields = ['-----']
-            self.costCombo.addItems('length')
+            self.costCombo.addItem('length')
             self.costCombo.addItems(fields)
 
     def getCostField(self):


### PR DESCRIPTION
The addItems function for the QComboBox requires a list. Replaced with addItem function.